### PR TITLE
[Blog] Add web syndication feeds

### DIFF
--- a/blog.go
+++ b/blog.go
@@ -69,6 +69,16 @@ type BlogEntry struct {
 	templateName string
 }
 
+// GetTime returns the timestamp corresponding to the moment the blog entry has
+// been published. It matches the datetime string on the blog.
+func (e *BlogEntry) GetTime() time.Time {
+	if e.Pushes != nil {
+		return e.Pushes[0].Delivered
+	} else {
+		return DateInDevLocation(e.Date).Time
+	}
+}
+
 // Blog bundles all blog entries, sorted from newest to oldest.
 type Blog []BlogEntry
 
@@ -188,14 +198,10 @@ func (e BlogEntry) Render(filters []string) Post {
 
 	post := Post{
 		Date:    e.Date,
+		Time:    e.GetTime(),
 		Tags:    e.Tags,
 		Filters: filters,
 		Body:    template.HTML(b.String()),
-	}
-	if e.Pushes != nil {
-		post.Time = e.Pushes[0].Delivered
-	} else {
-		post.Time = DateInDevLocation(e.Date).Time
 	}
 
 	for i := len(e.Pushes) - 1; i >= 0; i-- {

--- a/feed.go
+++ b/feed.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gorilla/feeds"
+)
+
+// stripArticleRegexp matches <article id="{{.Date}}"> opening tags and
+// </article> closing tags. They're stripped from the output because they're
+// commonly blacklisted and it doesn't make much sense to have them in a feed.
+var stripArticleRegexp = regexp.MustCompile(`(<article id="[0-9-]+">|</article>)`)
+
+// FeedHandler provides net/http handlers for blog feed generation. It relies
+// on blog entries being sorted from the newest to the oldest.
+type FeedHandler struct {
+	Blog     *Blog
+	SiteURL  string
+	BlogPath string
+}
+
+// getModTime returns the last modification time of the blog.
+func (h *FeedHandler) getModTime() time.Time {
+	if len(*h.Blog) == 0 {
+		return time.Time{}
+	}
+	return (*h.Blog)[0].GetTime()
+}
+
+// getFeed generates a feed from the rendered blog entries.
+func (h *FeedHandler) getFeed() *feeds.Feed {
+	feed := &feeds.Feed{
+		Title:       "Rec98",
+		Link:        &feeds.Link{Href: h.SiteURL + h.BlogPath},
+		Description: "The Touhou PC-98 Restoration Project",
+		Updated:     h.getModTime(),
+	}
+	for post := range h.Blog.Posts(nil) {
+		var b strings.Builder
+		pagesExecute(&b, "blog_post.html", &post)
+		content := b.String()
+		// NOTE(handlerug): Yes, I *will* use regular expressions to
+		// parse HTML :zunpet:
+		content = stripArticleRegexp.ReplaceAllString(content, "")
+		link := fmt.Sprintf("%s%s/%s", h.SiteURL, h.BlogPath, post.Date)
+		feed.Add(&feeds.Item{
+			Id:      link,
+			Link:    &feeds.Link{Href: link},
+			Created: post.Time,
+			Content: content,
+		})
+	}
+	return feed
+}
+
+// processRequest checks the HTTP method and handles conditional requests. It
+// checks the If-Modified-Since header, and sets the Last-Modified header to
+// the last blog entry's date. The return value indicates whether the request
+// needs to be handled further.
+func (h *FeedHandler) processRequest(wr http.ResponseWriter, req *http.Request) bool {
+	if req.Method != "GET" && req.Method != "HEAD" {
+		wr.WriteHeader(http.StatusMethodNotAllowed)
+		return false
+	}
+
+	// If there are no blog posts, we don't have anything to compare the
+	// timestamps to. Generate the feeds unconditionally.
+	if len(*h.Blog) == 0 {
+		return true
+	}
+
+	modTime := h.getModTime()
+	wr.Header().Set("Last-Modified", modTime.UTC().Format(http.TimeFormat))
+	t, err := http.ParseTime(req.Header.Get("If-Modified-Since"))
+	if err != nil {
+		return true
+	}
+	// The Last-Modified header has sub-second precision truncated (due to
+	// the http.TimeFormat having that omitted), so truncate modTime too.
+	modTime = modTime.Truncate(time.Second)
+	if modTime.Before(t) || modTime.Equal(t) {
+		wr.WriteHeader(http.StatusNotModified)
+		return false
+	}
+	return true
+}
+
+// HandleRSS responds with an RSS 2.0 feed of the blog.
+func (h *FeedHandler) HandleRSS(wr http.ResponseWriter, req *http.Request) {
+	if !h.processRequest(wr, req) {
+		return
+	}
+	wr.Header().Set("Content-Type", "application/rss+xml")
+	h.getFeed().WriteRss(wr)
+}
+
+// HandleAtom responds with an Atom feed of the blog.
+func (h *FeedHandler) HandleAtom(wr http.ResponseWriter, req *http.Request) {
+	if !h.processRequest(wr, req) {
+		return
+	}
+	wr.Header().Set("Content-Type", "application/atom+xml")
+	h.getFeed().WriteAtom(wr)
+}
+
+// HandleJSON responds with a JSON Feed (version 1) of the blog.
+func (h *FeedHandler) HandleJSON(wr http.ResponseWriter, req *http.Request) {
+	if !h.processRequest(wr, req) {
+		return
+	}
+	// The content type for the version 1.1 of JSON feeds is
+	// application/feed+json, by the way.
+	wr.Header().Set("Content-Type", "application/json")
+	h.getFeed().WriteJSON(wr)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/gocarina/gocsv v0.0.0-20220531201732-5f969b02b902
+	github.com/gorilla/feeds v1.1.1
 	github.com/gorilla/mux v1.8.0
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF0
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/gorilla/feeds v1.1.1 h1:HwKXxqzcRNg9to+BbvJog4+f3s/xzvtZXICcQGutYfY=
+github.com/gorilla/feeds v1.1.1/go.mod h1:Nk0jZrvPFZX1OBe5NPiddPw7CfwF6Q9eqzaBbaightA=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/header.html
+++ b/header.html
@@ -4,7 +4,12 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	{{if eq .TemplateName "legal" -}}
-		<meta name="robots" content="noindex, noarchive" />
+	<meta name="robots" content="noindex, noarchive" />
+	{{- end}}
+	{{if hasprefix .TemplateName "blog" -}}
+	<link rel="alternate" href="/blog/feed.xml" type="application/rss+xml" />
+	<link rel="alternate" href="/blog/feed.atom" type="application/atom+xml" />
+	<link rel="alternate" href="/blog/feed.json" type="application/json" />
 	{{- end}}
 	<link rel="stylesheet" href="{{call $.StaticFileURL "main.css"}}" />
 	<script src="{{call $.StaticFileURL "main.js"}}"></script>

--- a/main.go
+++ b/main.go
@@ -211,7 +211,7 @@ func HTMLScreenY(v int) template.HTML {
 }
 
 // HTML200Y formats v as a Y coordinate in the PC-98 VRAM space, in
-//  line-doubled 640×200 mode.
+// line-doubled 640×200 mode.
 func HTML200Y(v int) template.HTML {
 	return HTMLPC98Y("vram200", "Y coordinate in 640×200 VRAM space", v)
 }
@@ -284,6 +284,9 @@ var pages = template.New("").Funcs(map[string]interface{}{
 		}()
 		return ret
 	},
+
+	// String munging, safe
+	"hasprefix": strings.HasPrefix,
 
 	// Markup, safe
 	"HTML_Date":         HTMLDate,
@@ -426,7 +429,7 @@ func main() {
 
 	// Blog
 	// ----
-	NewBlog(pages, pushes, blogTags, func(blog Blog) map[string]interface{} {
+	blog := NewBlog(pages, pushes, blogTags, func(blog Blog) map[string]interface{} {
 		return map[string]interface{}{
 			"Blog_Posts":            blog.Posts,
 			"Blog_PostLink":         blog.PostLink,
@@ -442,6 +445,11 @@ func main() {
 			},
 		}
 	}).AutogenerateTags(&repo)
+	feedHandler := FeedHandler{
+		Blog:     &blog,
+		SiteURL:  "https://rec98.nmlgc.net",
+		BlogPath: "/blog",
+	}
 	// ----
 
 	pages = template.Must(pages.ParseGlob("*.html"))
@@ -469,6 +477,9 @@ func main() {
 	r.Handle("/faq", pagesHandler("faq.html"))
 	r.Handle("/fundlog", pagesHandler("fundlog.html"))
 	r.Handle(blogURLPrefix, pagesHandler("blog.html"))
+	r.Handle(blogURLPrefix+"/feed.xml", http.HandlerFunc(feedHandler.HandleRSS))
+	r.Handle(blogURLPrefix+"/feed.atom", http.HandlerFunc(feedHandler.HandleAtom))
+	r.Handle(blogURLPrefix+"/feed.json", http.HandlerFunc(feedHandler.HandleJSON))
 	r.Handle(blogURLPrefix+"/tag", pagesHandler("blog_taglist.html"))
 	r.Handle(blogURLPrefix+"/{date}", pagesHandler("blog_single.html"))
 	r.Handle(


### PR DESCRIPTION
I've been following the project for quite a while. Because I'm not using Twitter, I'm subscribed to Rec98 updates using the Nitter's RSS feed, which works okay, but the formatting is not great and honestly it doesn't work very well for microblogs like Twitter. I've been planning to send a patch adding feeds for some time, and today I finally bit the bullet.

Some notes:
- This pull request adds a dependency on https://github.com/gorilla/feeds. The project already depends on a package from the same team, https://github.com/gorilla/mux, but I thought I'd point it out anyway.
- Three formats are supported: RSS 2.0, Atom, and JSON Feed. Maybe only one is enough?
- All posts are exposed in the feeds. I think it's useful for crawling or archiving purposes. The code also supports conditional requests, so proper feed readers won't hammer the website by re-requesting the whole feed every hour or something.
- I've been putting off implementing this because I thought it'd be impossible to properly format the post content for feed readers, but the HTML markup is actually very clean and doesn't depend on JavaScript. My job was to just render `blog_post.html`, then strip the outer `<article>` tag. Thanks for clean HTML!
- Feed items don't have a title. [Miniflux](https://miniflux.app) shows the post URL in this case. It looks fine to me (my previous idea was to use `Blog post {{.Date}}` as the title anyway), but you're free to suggest something else. Besides, post URLs are much better than the whole tweet content used as the title :P
- Changes to already published blog posts won't trigger a change in the `Last-Modified` timestamp (because there's nothing saying it has been changed), so feed readers that support conditional requests won't see the change unless they haven't updated the feed or a new post is published. I don't think it's a big issue, but pointing it out anyway.
- Feeds should back-reference the HTML version of the feed and the blog posts. Right now, `rec98.nmlgc.net` is hard-coded. I'd imagine if anyone were up to fork this website and use it for their own purposes, they could easily change the string. Maybe a new `db/website_metadata.tsv` file is warranted...
- I've removed extraneous whitespace from `main.go:214` while running gofmt. gofmt thought the space was the start of a preformatted block, so it replaced the space with a tab per new Go docstring rules (my Go toolchain's version is 1.19). I can split this change out into a separate commit if you want.
- I've also de-indented the `<meta name="robots" ...>` line in header.html, and added new `<link>` elements at the same indentation level. I prioritized code and markup consistency over "making as little changes as possible", because if I put `<link>` elements at a deeper indentation level, the resulting HTML markup would have wrong indentation (first `<link>` line — single tab, second and third `<link>` line — double tab), which is clearly a regression.