### PR TITLE
Add licenses

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,96 @@
+# Licenses
+
+(Written by [Nmlgc](https://github.com/nmlgc).)
+
+## [CC0 1.0]
+
+Applies to the text content in the blog, the databases, and any files embedded
+in the blog that do not contain elements copyrighted by third parties:
+
+* `db/*.tsv`
+* `blog/*.html`
+* `blog/2019-08*`
+* `blog/2019-09-04*`
+* `blog/2021-09-12*`
+* `static/favicon.ico`
+* `static/faq-pi-ranges.svg`
+* `static/logo.png`
+
+### Rationale
+
+I did consider adding the [Attribution clause]; after all, keeping the community
+aware of this project is a big component of its ongoing success. But then I
+noticed that the actual things that people are likely to copy-paste from the
+blog are screenshots and videos of copyrighted games, which in turn makes these
+screenshots and videos copyrighted and not licensable.\
+That only leaves the text content on the blog. Due to its technical nature, it's
+way more likely to be shared in paraphrased or summarized form, which bypasses
+the need for attribution anyway.
+
+Also, the blog posts mainly discuss observable facts about a third-party game.
+In that light, it's hard to argue that alternative descriptions of these facts,
+released later, constitute a derivative work of a corresponding ReC98 blog post.
+For an example, see the [alternate explanation of TH01's unused and glitch
+stages], posted to *The Cutting Room Floor* a few days after ReC98 covered the
+latter in the [2022-08-14 blog post](https://rec98.nmlgc.net/blog/2022-08-14).\
+Therefore, putting the entire blog text into the public domain is much less of a
+headache for everyone. The community has always been attributing this project as
+a whole even without a license, and will likely continue to do so.
+
+## [GNU Affero General Public License v3.0]
+
+Applies to all code written for the website:
+
+* `.gitignore`
+* `*.css`
+* `*.go`
+* `*.html` (only on the root directory of this repository)
+* `*.js`
+* `go.mod`
+* `go.sum`
+
+### Rationale
+
+Chosen mainly to keep open the possibility of integrating code from DOSBox-X
+(which itself is GPL'd), like the ZMBV codec or full-blown PC-98 emulation, on
+the website itself. I've also been sympathetic to the GPL for a long time, and
+especially lately after seeing how companies typically treat open-source
+software.\
+If you want to reuse parts of this codebase under a different license, feel free
+to contact me, and we might work something out.
+
+## [GNU General Public License v2.0]
+
+* `blog/2020-09-03-tup-bac02a5-win32.zip`
+  (archive contains a link to the source code repository)
+
+## [GitHub logo usage terms]
+
+* `static/github.svg`
+
+## [Twitter Trademark Guidelines]
+
+* `static/twitter.svg`
+
+## [SIL Open Font License, Version 1.1]
+
+* `static/video.woff2` (a derivative of [Catrinity](https://catrinity-font.de))
+
+## No license
+
+All other files not covered by any of the licenses above. These include
+
+* screenshots, videos, and mod downloads embedded in the blog
+* game icons and custom emoji
+* meme images with unclear copyright holders
+
+----
+
+[Attribution clause]: https://creativecommons.org/licenses/by/4.0/
+[CC0 1.0]: https://creativecommons.org/publicdomain/zero/1.0/
+[GNU General Public License v2.0]: https://www.gnu.org/licenses/old-licenses/gpl-2.0
+[GNU Affero General Public License v3.0]: https://www.gnu.org/licenses/agpl-3.0.html
+[GitHub logo usage terms]: https://github.com/logos
+[Twitter Trademark Guidelines]: https://about.twitter.com/en/who-we-are/brand-toolkit
+[alternate explanation of TH01's unused and glitch stages]: https://tcrf.net/index.php?title=Touhou_Reiiden:_The_Highly_Responsive_to_Prayers&oldid=1286863#Unused_Levels
+[SIL Open Font License, Version 1.1]: https://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web

--- a/faq.html
+++ b/faq.html
@@ -598,6 +598,28 @@ DEATHBOMB_WINDOW = 8
 
 
 
+{{template "<q>" "website-contributions"}}
+	What about contributing code to the website?
+</h3>
+<p>
+	There is a wide array of potential features that could be added to this
+	site. Better accessibility for progress tables and syntax highlighting for
+	code snippets are two examples of features that I already have in mind for
+	future website pushes. Other features might be cool to have, but are maybe
+	too expensive relative to their usefulness, such as {{Blog_PostLink
+	"2022-10-31" "porting the ZMBV codec to the Web for efficient lossless video support on the blog"}}. And of course, there might be features that I
+	haven't even thought about so far.<br />
+	Unlike the core reverse-engineering business, improving the website is
+	something I only get to do maybe once or twice a year, as a side project.
+	That's why I would also highly appreciate you helping out in that regard.
+</p><p>
+	Note that any code contributions to the website will be licensed under the
+	<a href="https://github.com/nmlgc/rec98.nmlgc.net/blob/master/LICENSE.md">AGPL.</a>
+</p>
+{{template "</q>"}}
+
+
+
 {{template "<q>" "cap-why"}}
 	Why a cap?
 </h3>
@@ -759,7 +781,9 @@ DEATHBOMB_WINDOW = 8
 			I agree that remote content from <code>paypal.com</code> is loaded,
 			and that the data of my contribution will be processed, stored, and
 			made publicly available as seen in the <a
-			href="/fundlog">crowdfunding log</a>.<br />
+			href="/fundlog">crowdfunding log</a>, under a <a
+			href="https://github.com/nmlgc/rec98.nmlgc.net/blob/master/LICENSE.md">public-domain
+			license</a>.<br />
 			I will have the option to stay anonymous though.
 		</label>
 	</p><p>


### PR DESCRIPTION
Someone asked the dreaded license question earlier this week, and I agree that it should be settled sooner rather than later.

After lots of consideration, I've arrived at

* [AGPL](https://www.gnu.org/licenses/agpl-3.0.html) for website code, and
* [CC0](https://creativecommons.org/publicdomain/zero/1.0/) for databases.

See the new [LICENSE.md](https://github.com/nmlgc/rec98.nmlgc.net/blob/licenses/LICENSE.md) for my rationale behind both these choices.

## What about [the main code repository](https://github.com/nmlgc/ReC98)?

Since I'm not a lawyer, the best choice is follow the consensus reached by other decompilation and reverse-engineering projects: The code is copyrighted by the original developer (ZUN in our case), and I can't legally apply any license on it.

* <https://github.com/pret/pokered/issues/347>
* <https://github.com/pret/pokeemerald/issues/1569>
* <https://github.com/zeldaret/oot/pull/1194>

The Diablo project did put a license on their code, but the [corresponding PR](https://github.com/diasurgical/devilution/pull/2279) suggests that they just made up something that sounded reasonable.

## Permission

To apply these new licenses, I would need the permission of all the other contributors:

* [x] @handlerug (for the web syndication feed feature implemented in #6, would now fall under AGPL)
* [x] @spaztron64 (for the few blog sentences that I attributed to you, would now fall under CC0)