### PR TITLE
[Videos] [Pipeline] Use proper permissions with os.MkdirAll

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -31,7 +31,7 @@ func CacheLoad[Payload any](basename string) (ret Payload, err error) {
 func CacheSave(basename string, data any) {
 	fn := cacheFN(basename)
 	dir, _ := filepath.Split(fn)
-	FatalIf(os.MkdirAll(dir, 0600))
+	FatalIf(os.MkdirAll(dir, 0700))
 	f, err := os.Create(fn)
 	FatalIf(err)
 	enc := gob.NewEncoder(f)

--- a/video.go
+++ b/video.go
@@ -152,7 +152,7 @@ const (
 // necessary directories beforehand.
 func (f *FFMPEG) Encode(encodedFN string, sourceFN string, codec *FFMPEGCodec) {
 	encodedDir, _ := filepath.Split(encodedFN)
-	FatalIf(os.MkdirAll(encodedDir, 0600))
+	FatalIf(os.MkdirAll(encodedDir, 0700))
 	passCount := 1
 	if codec.TwoPass {
 		passCount = 2


### PR DESCRIPTION
On filesystems that actually support the Unix-like permission system (like filesystems used by Linux, *BSD and macOS, and not NTFS), the execute permission is required to read file contents in a directory.