### PR TITLE
[Videos] [Player] Integrate the ZMBV codec using Wasm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ blog/video/*
 cache/
 db/incoming.tsv
 db/paypal_auth.tsv
+node_modules/
+*.bundle.js
+*.bundle.js.map

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nmlgc/rec98.nmlgc.net
 go 1.19
 
 require (
+	github.com/evanw/esbuild v0.17.15
 	github.com/go-git/go-git/v5 v5.6.1
 	github.com/gocarina/gocsv v0.0.0-20230325173030-9a18a846a479
 	github.com/gorilla/feeds v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
+github.com/evanw/esbuild v0.17.15 h1:SyCbMVh61kWVC9klvH/iugLzvG/JDwA5hEpnBRx+Lro=
+github.com/evanw/esbuild v0.17.15/go.mod h1:iINY06rn799hi48UqEnaQvVfZWe6W9bET78LbvN8VWk=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
 github.com/gliderlabs/ssh v0.3.5/go.mod h1:8XB4KraRrX39qHhT6yxPsHedjA08I/uBVwj4xC+/+z4=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=

--- a/header.html
+++ b/header.html
@@ -13,6 +13,7 @@
 	<link rel="stylesheet" href="{{call $.StaticFileURL "tab-switcher.css"}}" />
 	<link rel="stylesheet" href="{{call $.StaticFileURL "video.css"}}" />
 	<script src="{{call $.StaticFileURL "tab-switcher.js"}}"></script>
+	<script src="{{call $.StaticFileURL "zmbv-video.ts"}}" data-worker-url="{{call $.StaticFileURL "zmbv-worker.ts"}}"></script>
 	<script src="{{call $.StaticFileURL "video.js"}}"></script>
 	{{- end}}
 	<link rel="stylesheet" href="{{call $.StaticFileURL "main.css"}}" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "rec98.nmlgc.net",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "fflate": "^0.7.4"
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="
+    }
+  },
+  "dependencies": {
+    "fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "fflate": "^0.7.4"
+  }
+}

--- a/static/video.css
+++ b/static/video.css
@@ -58,7 +58,29 @@ rec98-video>div.video-wrap {
 	display: block;
 }
 
-:fullscreen rec98-video video {
+rec98-zmbv-video {
+	font-size: 0;
+}
+
+rec98-zmbv-video canvas {
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+}
+
+rec98-zmbv-video img.zmbv-video-poster {
+	max-width: 100%;
+	max-height: none;
+}
+
+rec98-zmbv-video canvas,
+rec98-zmbv-video img.zmbv-video-poster {
+	image-rendering: pixelated; /* For Chrome */
+	image-rendering: crisp-edges; /* For Firefox */
+}
+
+:fullscreen rec98-video video,
+:fullscreen rec98-video rec98-zmbv-video {
 	position: absolute;
 	left: 0;
 	width: 100%;
@@ -66,21 +88,24 @@ rec98-video>div.video-wrap {
 }
 
 /* Firefox ignores rules that also match a `:-webkit-full-screen` selector? */
-:-webkit-full-screen rec98-video video {
+:-webkit-full-screen rec98-video video,
+:-webkit-full-screen rec98-video rec98-zmbv-video {
 	position: absolute;
 	left: 0;
 	width: 100%;
 	height: 100%;
 }
 
-rec98-video video {
+rec98-video video,
+rec98-video rec98-zmbv-video {
 	grid-column: 1;
 	grid-row: 1;
 	max-width: 100%;
 	height: auto;
 }
 
-rec98-video video.active {
+rec98-video video.active,
+rec98-video rec98-zmbv-video.active {
 	z-index: 1;
 }
 
@@ -95,7 +120,8 @@ rec98-video .controls {
 }
 
 /* Firefox requires an explicit grid without gaps for `height: 100%` to work */
-rec98-video.with-switcher video {
+rec98-video.with-switcher video,
+rec98-video.with-switcher rec98-zmbv-video {
 	grid-row: 2;
 }
 

--- a/static/video.js
+++ b/static/video.js
@@ -622,9 +622,34 @@ class ReC98Video extends HTMLElement {
 
 		// Reparent videos
 		// ---------------
-		this.videos = this.getElementsByTagName("video");
-		for(let i = 0; i < this.videos.length; i++) {
-			this.eVideoWrap.appendChild(this.videos[0]);
+		this.videos = Array.from(this.getElementsByTagName("video")).map(video => {
+			// If we have the lossless source, turn the video into a
+			// ZMBVVideoElement.
+			if(video.dataset.lossless) {
+				const newVideo = new ReC98ZMBVVideo();
+				newVideo.className = video.className;
+				newVideo.src = video.dataset.lossless;
+				newVideo.poster = video.poster;
+				newVideo.loop = video.loop;
+				newVideo.width = video.width;
+				newVideo.height = video.height;
+				for(const attr of video.attributes) {
+					newVideo.setAttribute(attr.name, attr.value);
+				}
+				while(video.children.length > 0) {
+					if(video.children[0].tagName.toLowerCase().startsWith("rec98-")) {
+						newVideo.appendChild(video.children[0]);
+					} else {
+						video.children[0].remove();
+					}
+				}
+				video.remove();
+				video = newVideo;
+			}
+			return video;
+		});
+		for(const video of this.videos) {
+			this.eVideoWrap.appendChild(video);
 		}
 		// ---------------
 

--- a/static/zmbv-video.ts
+++ b/static/zmbv-video.ts
@@ -1,0 +1,313 @@
+class ReC98ZMBVVideo extends HTMLElement {
+	static workerURL = document.currentScript?.dataset.workerUrl;
+
+	static intersectionObserver = new IntersectionObserver((entries, observer) => {
+		for(const entry of entries) {
+			if(entry.isIntersecting) {
+				const videoElement = entry.target as ReC98ZMBVVideo;
+				observer.unobserve(videoElement);
+				videoElement.onVisibleInViewport();
+			}
+		}
+	}, {
+		rootMargin: "0px 0px 1000px 0px",
+	});
+
+	#frameCount = 0;
+	#frameDurationMicrosec = 1;
+	#currentFrameStartTime = 0;
+	#currentFrame = 0;
+	#canPlay = false;
+	#seeking = false;
+	#paused = true;
+	loop = false;
+
+	/** @type {string} */
+	#src;
+
+	/** @type {HTMLImageElement} */
+	#posterImage;
+
+	/** @type {string} */
+	#posterSrc;
+
+	/** @type {HTMLCanvasElement} */
+	#canvas;
+
+	/** @type {?CanvasRenderingContext2D} */
+	#ctx;
+
+	/** @type {?ImageData} */
+	#imageData;
+
+	/** @type {?Worker} */
+	#worker;
+
+	/** @type {?Promise} */
+	#loadPromise;
+
+	/** @type {?number} */
+	#frameRequested;
+
+	constructor() {
+		super();
+
+		this.#canvas = document.createElement("canvas");
+		this.appendChild(this.#canvas);
+
+		this.#posterImage = new Image();
+		this.#posterImage.onload = () => {
+			if(!this.#canPlay) {
+				this.#initCtxIfNeeded();
+				this.#ctx.drawImage(this.#posterImage, 0, 0);
+			}
+		};
+	}
+
+	disconnectedCallback() {
+		ReC98ZMBVVideo.intersectionObserver.unobserve(this);
+	}
+
+	onVisibleInViewport() {
+		if(this.#posterImage.src !== this.#posterSrc) {
+			this.#posterImage.src = this.#posterSrc;
+		}
+	}
+
+	#initCtxIfNeeded() {
+		if(!this.#ctx) {
+			this.#ctx = this.#canvas.getContext("2d", { alpha: false });
+		}
+	}
+
+	get src() {
+		return this.#src;
+	}
+
+	set src(src) {
+		this.#src = src;
+		this.#loadPromise = null;
+		this.#frameRequested = null;
+		this.#worker?.terminate();
+		this.#worker = null;
+
+		this.#imageData = null;
+		if(this.#ctx) {
+			if(this.#posterImage.naturalWidth > 0 && this.#posterImage.naturalHeight > 0) {
+				this.#ctx.drawImage(this.#posterImage, 0, 0);
+			} else {
+				this.#ctx.clearRect(0, 0, this.#canvas.width, this.#canvas.height);
+			}
+		}
+
+		this.#canPlay = false;
+		this.#paused = true;
+		this.#seeking = false;
+		this.#currentFrame = 0;
+		this.#frameDurationMicrosec = 1;
+		this.#frameCount = 0;
+	}
+
+	/**
+	 * @returns {?string}
+	 */
+	get poster() {
+		return this.#posterSrc;
+	}
+
+	/**
+	 * @param {string} url
+	 */
+	set poster(url) {
+		this.#posterSrc = url;
+		ReC98ZMBVVideo.intersectionObserver.observe(this);
+	}
+
+	get width() {
+		return this.#canvas.width;
+	}
+
+	set width(newWidth) {
+		if(this.#canvas.width !== newWidth) {
+			this.#canvas.width = newWidth;
+			if(this.#canvas.height) {
+				this.#canvas.style.aspectRatio = `${this.#canvas.width} / ${this.#canvas.height}`;
+			}
+		}
+	}
+
+	get height() {
+		return this.#canvas.height;
+	}
+
+	set height(newHeight) {
+		if(this.#canvas.height !== newHeight) {
+			this.#canvas.height = newHeight;
+			if(this.#canvas.height) {
+				this.#canvas.style.aspectRatio = `${this.#canvas.width} / ${this.#canvas.height}`;
+			}
+		}
+	}
+
+	get currentFrame() {
+		return this.#currentFrame;
+	}
+
+	set currentFrame(newFrame) {
+		if(this.#currentFrame === newFrame) {
+			return;
+		}
+		if(newFrame < 0) newFrame = 0;
+		if(newFrame >= this.#frameCount) newFrame = this.#frameCount - 1;
+		if(this.#paused) {
+			this.dispatchEvent(new Event("seeking"));
+		}
+		this.#currentFrame = newFrame;
+		this.#sendRequest();
+		this.dispatchEvent(new Event("timeupdate"));
+	}
+
+	#sendRequest() {
+		if(this.#frameRequested === null) {
+			this.#worker.postMessage({
+				kind: "request",
+				frame: this.#currentFrame,
+				width: this.#imageData.width,
+				height: this.#imageData.height,
+				output: this.#imageData.data.buffer,
+			}, [this.#imageData.data.buffer]);
+		}
+		this.#frameRequested = this.#currentFrame;
+	}
+
+	/**
+	 * @param {MessageEvent} event
+	 */
+	#onMessage(event) {
+		if(event.data.kind === "frame") {
+			const { frame, width, height, output } = event.data;
+			console.log("received %d", frame);
+			this.#imageData = new ImageData(new Uint8ClampedArray(output), width, height);
+			const frameRequested = this.#frameRequested;
+			this.#frameRequested = null;
+			if(frameRequested !== frame) {
+				this.#ctx.putImageData(this.#imageData, 0, 0);
+				this.#sendRequest();
+			} else if(this.#paused) {
+				this.#ctx.putImageData(this.#imageData, 0, 0);
+				this.dispatchEvent(new Event("seeked"));
+			}
+		}
+	}
+
+	get currentTime() {
+		return secondsFrom(this.#currentFrame, 1_000_000 / this.#frameDurationMicrosec);
+	}
+
+	set currentTime(newTime) {
+		const newFrame = frameFrom(newTime, 1_000_000 / this.#frameDurationMicrosec);
+		this.currentFrame = newFrame;
+	}
+
+	get duration() {
+		return secondsFrom(this.#frameCount, 1_000_000 / this.#frameDurationMicrosec);
+	}
+
+	get paused() {
+		return this.#paused;
+	}
+
+	get seeking() {
+		return this.#seeking;
+	}
+
+	load() {
+		if(!this.#loadPromise) {
+			this.#loadPromise = (async () => {
+				this.dispatchEvent(new Event("loadstart"));
+				this.#initCtxIfNeeded();
+
+				if(!ReC98ZMBVVideo.workerURL) {
+					throw new Error('<script> tag missing data-worker-url attribute');
+				}
+				const worker = new Worker(ReC98ZMBVVideo.workerURL);
+				const promise = new Promise((resolve, reject) => {
+					worker.onmessage = (event) => {
+						if(event.data.kind === "ready") {
+							resolve(event.data);
+						}
+					};
+					worker.onerror = reject;
+				});
+				worker.postMessage({ kind: "url", url: this.src });
+
+				const { width, height, frameCount, frameDurationMicrosec } = await (promise as any);
+				this.width = width;
+				this.height = height;
+				this.#imageData = this.#ctx.createImageData(width, height);
+				this.#frameCount = frameCount;
+				this.#frameDurationMicrosec = frameDurationMicrosec;
+
+				worker.onmessage = this.#onMessage.bind(this);
+				worker.onerror = null;
+				this.#worker = worker;
+
+				this.currentFrame = 0;
+				this.#canPlay = true;
+				this.#sendRequest();
+				this.dispatchEvent(new Event("canplay"));
+				this.dispatchEvent(new Event("canplaythrough"));
+			})();
+		}
+		return this.#loadPromise;
+	}
+
+	async play() {
+		if(!this.#canPlay) {
+			await this.load();
+		}
+		if(this.#paused) {
+			this.#paused = false;
+			this.#currentFrameStartTime = performance.now() - 1_000_000 / this.#frameDurationMicrosec;
+			const tick = () => {
+				if(this.#paused) return;
+				let newFrame = this.#currentFrame;
+				let delta = performance.now() - this.#currentFrameStartTime;
+				while(delta >= this.#frameDurationMicrosec / 1000) {
+					newFrame++;
+					delta -= this.#frameDurationMicrosec / 1000;
+				}
+				this.#currentFrameStartTime = performance.now() - delta;
+				if(newFrame > this.#frameCount - 1) {
+					if(this.loop) {
+						newFrame = 0;
+					} else {
+						newFrame = this.#frameCount - 1;
+						this.pause();
+						return;
+					}
+				}
+				console.log("intended  %d", newFrame);
+				if(this.#frameRequested === null) {
+					this.#ctx.putImageData(this.#imageData, 0, 0);
+				}
+				this.currentFrame = newFrame;
+				window.requestAnimationFrame(tick);
+			};
+			tick();
+			this.dispatchEvent(new Event("play"));
+		}
+	}
+
+	pause() {
+		if(!this.#paused) {
+			this.#paused = true;
+			this.dispatchEvent(new Event("pause"));
+		}
+	}
+}
+
+// NOTE(handlerug): I suppose esbuild has to be configured properly to remove this hack.
+(window as any).ReC98ZMBVVideo = ReC98ZMBVVideo;
+
+window.customElements.define("rec98-zmbv-video", ReC98ZMBVVideo);

--- a/static/zmbv-worker.ts
+++ b/static/zmbv-worker.ts
@@ -1,0 +1,627 @@
+import { Unzlib } from "fflate";
+
+/*
+ * Utilities
+ */
+
+function assert(condition: boolean, message?: string): asserts condition {
+	if(!condition) {
+		throw new Error(message ?? "Assertion failed");
+	}
+}
+
+function assertNonNull<T>(value: T, message?: string): asserts value is NonNullable<T> {
+	assert(value !== undefined && value !== null, message);
+}
+
+/*
+ * Constants
+ */
+
+// ZMBV version implemented by DOSBox
+const DBZV_VERSION_HIGH = 0;
+const DBZV_VERSION_LOW  = 1;
+
+// Compression algorithms
+const COMPRESSION_NONE = 0;
+const COMPRESSION_ZLIB = 1;
+
+// Max distance from zero of a motion vector
+const MAX_VECTOR = 16;
+
+// Frame tag bit mask
+const TAG_KEYFRAME      = 0x01;
+const TAG_DELTA_PALETTE = 0x02;
+
+// Frame data layout
+const FORMAT_NONE  = 0x00;
+const FORMAT_1BPP  = 0x01;
+const FORMAT_2BPP  = 0x02;
+const FORMAT_4BPP  = 0x03;
+const FORMAT_8BPP  = 0x04;
+const FORMAT_15BPP = 0x05;
+const FORMAT_16BPP = 0x06;
+const FORMAT_24BPP = 0x07;
+const FORMAT_32BPP = 0x08;
+
+/*
+ * ZMBV decoding
+ */
+
+// From fflate
+type InflateState = {
+	// lmap
+	l?: Uint16Array;
+	// dmap
+	d?: Uint16Array;
+	// lbits
+	m?: number;
+	// dbits
+	n?: number;
+	// final
+	f?: number;
+	// pos
+	p?: number;
+	// byte
+	b?: number;
+	// lstchk
+	i?: boolean;
+};
+
+// From fflate
+type PrivateInflate = {
+	s: InflateState;
+	o: Uint8Array;
+	p: Uint8Array;
+	d: boolean;
+};
+
+/**
+ * Stores information about the layout of a motion block as stored in the
+ * decoder frame buffer.
+ */
+interface BlockInfo {
+	/**
+	 * Index of the first pixel of the block in the buffer.
+	 */
+	offset: number;
+
+	/**
+	 * Width of the block in pixels.
+	 */
+	dx: number;
+
+	/**
+	 * Height of the block in pixels.
+	 */
+	dy: number;
+}
+
+class ZMBVDecoder {
+	private decompressor: Unzlib;
+	private decompressedData = new Uint8Array();
+	private compression = COMPRESSION_NONE;
+	private pitch = 0;
+	private blockWidth = 0;
+	private blockHeight = 0;
+	private blockInfo: BlockInfo[] = [];
+	private oldFrame = new Uint32Array();
+	private newFrame = new Uint32Array();
+	private pixelSize = 4;
+	private currentFrame = -1;
+	private lastDecodedFrame = -1;
+	private frameCache: { [key: number]: {
+		frame: Uint32Array;
+		state: PrivateInflate["s"];
+		output: PrivateInflate["o"];
+	} } = {};
+	private frameCachingInterval = 0;
+
+	constructor(private width: number, private height: number, private frames: Uint8Array[]) {
+		this.decompressor = new Unzlib();
+		this.decompressor.ondata = (data) => {
+			// This callback is executed after every call to push()
+			this.decompressedData = data;
+		};
+	}
+
+	/**
+	 * Initializes the frame buffers, generates block information, and enables
+	 * frame caching if necessary.
+	 */
+	private setup() {
+		// Buffers are padded by MAX_VECTOR from every side. This lets us handle
+		// motion vectors going out of bounds and getting naturally zeroed out.
+		// On the following diagram, the dots are the actual image, and the
+		// zeros are the MAX_VECTOR padding:
+		//
+		// +----------------------------+
+		// |0000000000000000000000000000|
+		// |0000000000000000000000000000|
+		// |000......................000|
+		// |000......................000|
+		// |000......................000|
+		// |000......................000|
+		// |000......................000|
+		// |0000000000000000000000000000|
+		// |0000000000000000000000000000|
+		// +----------------------------+
+
+		this.pitch = this.width + 2 * MAX_VECTOR;
+		const frameSize = this.pitch * (this.height + 2 * MAX_VECTOR);
+		this.oldFrame = new Uint32Array(frameSize);
+		this.newFrame = new Uint32Array(frameSize);
+
+		// Populate block information.
+		this.blockInfo = [];
+		for(let y = 0; y < this.height; y += this.blockHeight) {
+			for(let x = 0; x < this.width; x += this.blockWidth) {
+				this.blockInfo.push({
+					offset: (y + MAX_VECTOR) * this.pitch + (x + MAX_VECTOR),
+					dx: Math.min(this.width - x, this.blockWidth),
+					dy: Math.min(this.height - y, this.blockHeight),
+				});
+			}
+		}
+
+		// If the interval between keyframes is too big (or there are not enough
+		// keyframes), enable frame caching.
+		let interval = 0, intervalSum = 0, keyframeCount = 0;
+		for(const frame of this.frames.slice(1)) {
+			if((frame[0] & TAG_KEYFRAME) !== 0) {
+				intervalSum += interval;
+				keyframeCount++;
+				interval = 0;
+			} else {
+				interval++;
+			}
+		}
+		const keyframeInterval = intervalSum === 0 ? Infinity : Math.floor(intervalSum / keyframeCount);
+		if(keyframeInterval >= 40) {
+			this.frameCachingInterval = 20;
+		}
+	}
+
+	decode(array: Uint8Array) {
+		const isKeyFrame = array[0] & TAG_KEYFRAME;
+		let frameData: Uint8Array;
+
+		if(isKeyFrame) {
+			const highVersion = array[1];
+			const lowVersion = array[2];
+			const compression = array[3];
+			const format = array[4];
+			const blockWidth = array[5];
+			const blockHeight = array[6];
+			frameData = array.subarray(7);
+
+			assert(highVersion === DBZV_VERSION_HIGH && lowVersion === DBZV_VERSION_LOW,
+				`Unsupported ZMBV codec version ${highVersion}.${lowVersion}: ` +
+				`the only supported version is ${DBZV_VERSION_HIGH}.${DBZV_VERSION_LOW}`);
+			assert(compression === COMPRESSION_NONE || compression === COMPRESSION_ZLIB,
+				`Unsupported compression type ${compression}: ` +
+				`only no compression (0) and zlib (1) are supported`);
+			assert(format === FORMAT_32BPP,
+				"Unsupported frame format: only 32 BPP is supported");
+			assert(blockWidth !== 0 && blockHeight !== 0,
+				"Block width/height must be greater than zero");
+
+			this.compression = compression;
+
+			if(
+				blockWidth !== this.blockWidth ||
+				blockHeight !== this.blockHeight
+			) {
+				this.blockWidth = blockWidth;
+				this.blockHeight = blockHeight;
+				this.setup();
+			}
+
+			// Reset the inflate state by calling the constructor again (yes).
+			// Save ondata to restore it after the call.
+			const ondata = this.decompressor.ondata;
+			Unzlib.call(this.decompressor);
+			this.decompressor.ondata = ondata;
+		} else {
+			frameData = array.subarray(1);
+		}
+
+		if(this.compression === COMPRESSION_ZLIB) {
+			this.decompressor.push(frameData);
+			frameData = this.decompressedData!;
+		}
+
+		let frameData32 = new Uint32Array(frameData.buffer, frameData.byteOffset);
+		if(isKeyFrame) {
+			for(let y = 0; y < this.height; y++) {
+				for(let x = 0; x < this.width; x++) {
+					this.newFrame[(y + MAX_VECTOR) * this.pitch + MAX_VECTOR + x] = frameData32[y * this.width + x];
+				}
+			}
+		} else {
+			[this.newFrame, this.oldFrame] = [this.oldFrame, this.newFrame];
+			frameData32 = frameData32.subarray(Math.ceil(this.blockInfo.length * 2 / 4));
+			let blockChangesOffset = 0;
+			const blocks = new Int8Array(frameData.buffer, frameData.byteOffset);
+			for(let i = 0; i < this.blockInfo.length; i++) {
+				const blockInfo = this.blockInfo[i];
+				const delta = blocks[i * 2] & 1;
+				const vx = blocks[i * 2] >> 1;
+				const vy = blocks[i * 2 + 1] >> 1;
+				if(delta) {
+					for(let y = 0; y < blockInfo.dy; y++) {
+						for(let x = 0; x < blockInfo.dx; x++) {
+							this.newFrame[blockInfo.offset + y * this.pitch + x] =
+								this.oldFrame[blockInfo.offset + (y + vy) * this.pitch + x + vx] ^
+								frameData32[blockChangesOffset++];
+						}
+					}
+				} else {
+					for(let y = 0; y < blockInfo.dy; y++) {
+						for(let x = 0; x < blockInfo.dx; x++) {
+							this.newFrame[blockInfo.offset + y * this.pitch + x] =
+								this.oldFrame[blockInfo.offset + (y + vy) * this.pitch + x + vx];
+						}
+					}
+				}
+			}
+		}
+	}
+
+	output(output: Uint8ClampedArray) {
+		for(let y = 0; y < this.height; y++) {
+			for(let x = 0; x < this.width; x++) {
+				const pixel = this.newFrame[(y + MAX_VECTOR) * this.pitch + MAX_VECTOR + x];
+				// BGRX → RGBA
+				output[(y * this.width + x) * this.pixelSize + 0] = (pixel >> 16) & 0xFF;
+				output[(y * this.width + x) * this.pixelSize + 1] = (pixel >> 8) & 0xFF;
+				output[(y * this.width + x) * this.pixelSize + 2] = (pixel >> 0) & 0xFF;
+				output[(y * this.width + x) * this.pixelSize + 3] = 0xFF;
+			}
+		}
+	}
+
+	presentFrame(newFrame: number, outputBuffer: ArrayBuffer) {
+		// Clamp the new frame number.
+		if(newFrame < 0) newFrame = 0;
+		if(newFrame >= this.frames.length) newFrame = this.frames.length - 1;
+
+		// If we"re ahead of the new frame…
+		if(this.currentFrame > newFrame) {
+			// Position ourselves one frame before the new one (because we have
+			// to decode it in order to display it!)
+			this.currentFrame = newFrame - 1;
+
+			while(
+				// We hit the beginning
+				this.currentFrame >= 0 &&
+				// We hit a keyframe
+				(this.frames[this.currentFrame + 1][0] & TAG_KEYFRAME) === 0 &&
+				// We hit a cached frame
+				!this.frameCache[this.currentFrame]
+			) {
+				// Rewind.
+				this.currentFrame--;
+			}
+		} else {
+			// If we"re behind, look for a cached frame before the new frame
+			// that also comes after the current frame.
+			for(let i = newFrame; i > this.currentFrame; i--) {
+				if(this.frameCache[i]) {
+					this.currentFrame = i;
+					break;
+				}
+			}
+		}
+
+		if(this.currentFrame !== this.lastDecodedFrame && this.frameCache[this.currentFrame]) {
+			const { frame, state, output } = this.frameCache[this.currentFrame];
+			this.newFrame = new Uint32Array(frame);
+			(this.decompressor as unknown as PrivateInflate).s = { ...state };
+			(this.decompressor as unknown as PrivateInflate).o = new Uint8Array(output);
+		}
+
+		while(this.currentFrame < newFrame) {
+			if(
+				// Caching is enabled
+				this.frameCachingInterval > 0 &&
+				// The caching interval passed
+				(this.currentFrame % this.frameCachingInterval) === 0 &&
+				// The frame has not yet been cached
+				!this.frameCache[this.currentFrame] &&
+				// The frame is not a keyframe (otherwise it"s useless)
+				(this.frames[this.currentFrame][0] & TAG_KEYFRAME) === 0
+			) {
+				// Copy some of the relevant state to the cache.
+				this.frameCache[this.currentFrame] = {
+					frame: new Uint32Array(this.newFrame),
+					state: { ...(this.decompressor as unknown as PrivateInflate).s },
+					output: new Uint8Array((this.decompressor as unknown as PrivateInflate).o),
+				};
+			}
+
+			const frame = this.frames[++this.currentFrame];
+			this.decode(frame);
+			this.lastDecodedFrame = this.currentFrame;
+		}
+
+		const output = new Uint8ClampedArray(outputBuffer);
+		this.output(output);
+	}
+}
+
+let decoder: ZMBVDecoder | undefined;
+
+/*
+ * AVI parsing
+ */
+
+type FourCC = number;
+
+type Rect = {
+	left: number;
+	top: number;
+	right: number;
+	bottom: number;
+};
+
+type RIFFChunk = RIFFList;
+
+interface RIFFList {
+	fcc: "LIST";
+	listType: string;
+	childChunks: RIFFChunk[];
+}
+
+interface AVIHeader {
+	mainHeader: AVIMainHeader;
+	streamList: AVIStream[];
+}
+
+interface AVIMainHeader {
+	microSecPerFrame: number;
+	maxBytesPerSec: number;
+	paddingGranularity: number;
+	flags: number;
+	totalFrames: number;
+	initialFrames: number;
+	streams: number;
+	suggestedBufferSize: number;
+	width: number;
+	height: number;
+}
+
+interface AVIStream {
+	index: number;
+	header: AVIStreamHeader;
+	format: AVIVideoStreamFormat | AVIUnknownStreamFormat;
+}
+
+interface AVIStreamHeader {
+	type: FourCC;
+	handler: FourCC;
+	flags: number;
+	priority: number;
+	language: number;
+	initialFrames: number;
+	scale: number;
+	rate: number;
+	start: number;
+	length: number;
+	suggestedBufferSize: number;
+	quality: number;
+	sampleSize: number;
+	frame: Rect;
+};
+
+interface AVIStreamFormat {
+	raw: Uint8Array;
+}
+
+interface AVIUnknownStreamFormat extends AVIStreamFormat {
+	formatType: "unknown";
+}
+
+interface AVIVideoStreamFormat extends AVIStreamFormat {
+	formatType: "video";
+	width: number;
+	height: number;
+	planes: number;
+	bitCount: number;
+	compression: FourCC;
+	sizeImage: number;
+	xPelsPerMeter: number;
+	yPelsPerMeter: number;
+	clrUsed: number;
+	clrImportant: number;
+	// XXX: a color table may follow this structure
+	// https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader
+}
+
+function fccToStr(fcc: FourCC) {
+	return String.fromCharCode(
+		fcc & 0xFF,
+		(fcc >> 8) & 0xFF,
+		(fcc >> 16) & 0xFF,
+		(fcc >> 24) & 0xFF,
+	);
+}
+
+function leUint16(array: Uint8Array, offset: number) {
+	return (
+		array[offset] |
+		(array[offset + 1] << 8)
+	) >>> 0;
+}
+
+function leSint32(array: Uint8Array, offset: number) {
+	return (
+		array[offset] |
+		(array[offset + 1] << 8) |
+		(array[offset + 2] << 16) |
+		(array[offset + 3] << 24)
+	);
+}
+
+function leUint32(array: Uint8Array, offset: number) {
+	return leSint32(array, offset) >>> 0;
+}
+
+function* parseRIFFList(array: Uint8Array) {
+	assert(fccToStr(leUint32(array, 0)) === "LIST");
+	const size = leUint32(array, 4);
+	for(let start = 12; start - 12 + 8 < size;) {
+		const childSize = leUint32(array, start + 4);
+		yield new Uint8Array(array.buffer, array.byteOffset + start, childSize + 8);
+		start += 8 + childSize + childSize % 2;
+	}
+}
+
+function parseAVIHeader(array: Uint8Array): AVIHeader {
+	let mainHeader: AVIMainHeader | undefined;
+	const streamList: AVIStream[] = [];
+	assert(fccToStr(leUint32(array, 8)) === "hdrl");
+	for(const chunk of parseRIFFList(array)) {
+		switch(fccToStr(leUint32(chunk, 0))) {
+		case "avih":
+			mainHeader = {
+				microSecPerFrame:    leUint32(chunk, 8),
+				maxBytesPerSec:      leUint32(chunk, 12),
+				paddingGranularity:  leUint32(chunk, 16),
+				flags:               leUint32(chunk, 20),
+				totalFrames:         leUint32(chunk, 24),
+				initialFrames:       leUint32(chunk, 28),
+				streams:             leUint32(chunk, 32),
+				suggestedBufferSize: leUint32(chunk, 36),
+				width:               leUint32(chunk, 40),
+				height:              leUint32(chunk, 44),
+			};
+			break;
+		case "LIST":
+			if(fccToStr(leUint32(chunk, 8)) !== "strl") {
+				continue;
+			}
+			let streamHeader: AVIStream["header"] | undefined;
+			let streamFormat: AVIStream["format"] | undefined;
+			for(const streamChunk of parseRIFFList(chunk)) {
+				switch(fccToStr(leUint32(streamChunk, 0))) {
+				case "strh":
+					streamHeader = {
+						type:                leUint32(streamChunk, 8),
+						handler:             leUint32(streamChunk, 12),
+						flags:               leUint32(streamChunk, 16),
+						priority:            leUint16(streamChunk, 20),
+						language:            leUint16(streamChunk, 22),
+						initialFrames:       leUint32(streamChunk, 24),
+						scale:               leUint32(streamChunk, 28),
+						rate:                leUint32(streamChunk, 32),
+						start:               leUint32(streamChunk, 36),
+						length:              leUint32(streamChunk, 40),
+						suggestedBufferSize: leUint32(streamChunk, 44),
+						quality:             leUint32(streamChunk, 48),
+						sampleSize:          leUint32(streamChunk, 52),
+						frame: {
+							left:   leSint32(streamChunk, 56),
+							top:    leSint32(streamChunk, 60),
+							right:  leSint32(streamChunk, 64),
+							bottom: leSint32(streamChunk, 68),
+						},
+					};
+					break;
+				case "strf":
+					if(streamHeader && fccToStr(streamHeader.type) === "vids") {
+						streamFormat = {
+							formatType:    "video",
+							raw:           streamChunk.subarray(8),
+							width:         leSint32(streamChunk, 12),
+							height:        leSint32(streamChunk, 16),
+							planes:        leUint16(streamChunk, 20),
+							bitCount:      leUint16(streamChunk, 22),
+							compression:   leUint32(streamChunk, 24),
+							sizeImage:     leUint32(streamChunk, 28),
+							xPelsPerMeter: leSint32(streamChunk, 32),
+							yPelsPerMeter: leSint32(streamChunk, 36),
+							clrUsed:       leUint32(streamChunk, 40),
+							clrImportant:  leUint32(streamChunk, 44),
+						}
+					} else {
+						streamFormat = {
+							formatType: "unknown",
+							raw: streamChunk.subarray(8),
+						};
+					}
+				}
+			}
+			assertNonNull(streamHeader);
+			assertNonNull(streamFormat);
+			streamList.push({
+				index: streamList.length,
+				header: streamHeader,
+				format: streamFormat,
+			});
+			break;
+		}
+	}
+	assertNonNull(mainHeader);
+	return { mainHeader, streamList };
+}
+
+async function initialize(url: string) {
+	const videoResp = await fetch(url);
+	const videoBuffer = await videoResp.arrayBuffer();
+	let array = new Uint8Array(videoBuffer);
+	assert(fccToStr(leUint32(array, 0)) === "RIFF");
+	assert(fccToStr(leUint32(array, 8)) === "AVI ");
+
+	array = array.subarray(12);
+	const header = parseAVIHeader(array);
+	const { width, height, microSecPerFrame } = header.mainHeader;
+	const stream = header.streamList.find(stream => fccToStr(stream.header.handler).toLowerCase() === "zmbv");
+	assertNonNull(stream);
+
+	while(!(fccToStr(leUint32(array, 0)) === "LIST" && fccToStr(leUint32(array, 8)) === "movi")) {
+		const size = leUint32(array, 4);
+		array = array.subarray(8 + size + size % 2);
+	}
+	array = array.subarray(0, leUint32(array, 4) + 8);
+
+	function* extractFrames(streamIdx: number, array: Uint8Array) {
+		for(const dataChunk of parseRIFFList(array)) {
+			const fcc = fccToStr(leUint32(dataChunk, 0));
+			if(fcc === "LIST" && fccToStr(leUint32(dataChunk, 8)) === "rec ") {
+				yield* extractFrames(streamIdx, dataChunk);
+			}
+			if(Number.parseInt(fcc.slice(0, 2)) === streamIdx) {
+				yield dataChunk.subarray(8);
+			}
+		}
+	}
+	const frames = [...extractFrames(stream.index, array)];
+
+	decoder = new ZMBVDecoder(width, height, frames);
+
+	postMessage({
+		kind: "ready",
+		width: width,
+		height: height,
+		frameCount: frames.length,
+		frameDurationMicrosec: microSecPerFrame,
+	});
+}
+
+function requestFrame({ frame, width, height, output }: { frame: number; width: number; height: number; output: ArrayBuffer; }) {
+	if(!decoder) return;
+	decoder.presentFrame(frame, output);
+	postMessage({ kind: "frame", frame, width, height, output }, {
+		transfer: [output],
+	});
+}
+
+addEventListener("message", (ev) => {
+	switch(ev.data.kind) {
+	case "url":
+		return initialize(ev.data.url);
+	case "request":
+		return requestFrame(ev.data);
+	}
+});


### PR DESCRIPTION
Ingredients:
- [ZMBV](https://github.com/joncampbell123/dosbox-x/tree/master/src/libs/zmbv) codec from DOSBox-X (GPL-2.0-or-later)
    - ~~Methods added: `~VideoCodec`, `Snapshot`, `RestoreFromSnapshot`, `OutputRGBA`~~
    - Methods modified: removed `Z_FINISH` from `DecompressFrame`
- [miniz](https://github.com/richgel999/miniz), a smaller alternative to zlib (MIT)
- `VideoDecoder` which is mainly glue code
- An adapter that mimics `HTMLVideoElement` but is actually a custom element that draws to a canvas to remove the need for special-casing the whole `video.js` file

Seeking works quite well. Buttery smooth on my main system, and acceptably smooth on my (underpowered) smartphone. I have not tested this code on iOS yet (will test tomorrow). I tested it in Safari for macOS.

I checked the compiled .wasm blob in, ~~but you can compile it using `make WASI_SDK=<path to WASI SDK>`. You can get the WASI SDK from [here](https://github.com/WebAssembly/wasi-sdk/releases). You also need a recent version of LLVM; mine is 14.0.6. **(EDIT: LLVM is bundled with WASI SDK)** It also makes a ton of assumptions about your environment which are not true, but the Makefile is probably going to the trash bin anyway. I'm going to split this commit up and reformat the new code accordingly tomorrow.~~
- ~~make or Tup? Something else?~~
- ~~Building this blob needs to be easier, the whole SDK situation is confusing. Maybe vendor required libraries so that you only need LLVM? But you still need a "special" build of LLVM with the WASM target compiled in~~
    - ~~Remove the blob from the repository or keep it?~~

~~I did not use Emscripten because I wanted more control over what gets compiled into the final binary and did not like the amount of glue JS code it usually generates. The blob is still quite large for my taste (44.5 KB) even after running it through `wasm-opt`, though. I will look into decreasing its size.~~

Using Emscripten now. Blob size is ~24 KB. The Makefile now contains a single command used for building the blob.

Decoding happens on the main thread now. I'm thinking if there is any benefit to running the decoder in a web worker.

Another thing to note is memory consumption. There are very few keyframes in this repository's AVI files, and seeking is quite slow if you just try to reset to the nearest keyframe then decode up to the current one. So I clone the decoder state (including zlib state) every `keyframe_interval` frames then use that as my keyframes. ~~Heap size is around 100 MB on average (total, JS heap + full WASM address space);~~ it's actually around 500 MB, wow! This is a problem. ~~I'll try to find out if there is anything preventing from GCing large ArrayBuffers or something, if possible.~~ Pretty much all of that is `WebAssembly.Memory`. I'll look into decreasing the size of decoder snapshots.

What do you think? With this change in I'm pretty sure you could drop AV1 and only keep VP8/VP9 as a fallback for browsers without WASM/custom elements/JS support. As an added bonus, the video is now scaled using nearest neighbor in all major browsers (`image-rendering: pixelated` applied to the `<canvas>` element).