### PR TITLE
[Paths] Fix Cache-Control max-age directive syntax

### DIFF
--- a/path.go
+++ b/path.go
@@ -38,7 +38,7 @@ func NewHostedPath(LocalPath string, URLPrefix string) *HostedPath {
 		},
 		srv: http.HandlerFunc(func(wr http.ResponseWriter, req *http.Request) {
 			if len(req.URL.RawQuery) > 0 {
-				wr.Header().Set("Cache-Control", "max-age: 31536000, immutable")
+				wr.Header().Set("Cache-Control", "max-age=31536000, immutable")
 			}
 			dir.ServeHTTP(wr, req)
 		}),


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc9111#name-cache-control

UPD: Or this: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#max-age