### PR TITLE
[Videos] [Pipeline] Add width and height attributes to <video>

### DIFF
--- a/blog.go
+++ b/blog.go
@@ -75,7 +75,8 @@ func (b *BlogVideo) Tag() (ret template.HTML) {
 		ret += ` class="active"`
 	}
 	ret += template.HTML(fmt.Sprintf(
-		` data-fps="%v" data-frame-count="%v"`,
+		` width="%v" height="%v" data-fps="%v" data-frame-count="%v"`,
+		b.Metadata.Width, b.Metadata.Height,
 		b.Metadata.FPS, b.Metadata.FrameCount,
 	))
 	ret += (` data-lossless="` + b.Lossless + `"`)


### PR DESCRIPTION
This prevents layout shift when the video metadata is loaded, which is particularly expensive on the blog's home page…

Before and after:

https://user-images.githubusercontent.com/24986597/212485263-46ebd8f1-7746-4c6e-b97a-1ee300368355.mp4

