### PR TITLE
[Videos] [Player] Force intrinsic size and aspect ratio

### DIFF
--- a/blog.go
+++ b/blog.go
@@ -75,7 +75,7 @@ func (b *BlogVideo) Tag() (ret template.HTML) {
 		ret += ` class="active"`
 	}
 	ret += template.HTML(fmt.Sprintf(
-		` width="%v" height="%v" data-fps="%v" data-frame-count="%v"`,
+		` width="%v" height="%v" data-fps="%v" data-frame-count="%v" style="aspect-ratio: %[1]d / %[2]d"`,
 		b.Metadata.Width, b.Metadata.Height,
 		b.Metadata.FPS, b.Metadata.FrameCount,
 	))

--- a/static/video.css
+++ b/static/video.css
@@ -62,6 +62,7 @@ rec98-video>div.video-wrap {
 	position: absolute;
 	left: 0;
 	width: 100%;
+	height: 100%;
 }
 
 /* Firefox ignores rules that also match a `:-webkit-full-screen` selector? */
@@ -69,12 +70,14 @@ rec98-video>div.video-wrap {
 	position: absolute;
 	left: 0;
 	width: 100%;
+	height: 100%;
 }
 
 rec98-video video {
 	grid-column: 1;
 	grid-row: 1;
-	height: 100%;
+	max-width: 100%;
+	height: auto;
 }
 
 rec98-video video.active {


### PR DESCRIPTION
Use video width, limit it to the max horizontal space available, and infer height from aspect ratio. For full-screen mode, set both width and height to 100%.

Setting `aspect-ratio` explicitly is required because browser vendors only implemented inferring it for `<img>` elements, even though `<video>` was mentioned in discussions. One could have tried using `aspect-ratio: attr(width) / attr(height)`, but `attr` only really works for the `content` property in major browsers.

Safari interpreted `height: 100%` as "the height of the grid container" (i.e. `rec98-video`), so this got fixed as well. Before:

<img width="748" alt="Video player layout in Safari before the change" src="https://user-images.githubusercontent.com/24986597/212499199-4d456707-2baa-4715-b9d3-6ac96f8549bb.png">

After:

<img width="748" alt="Video player layout in Safari after the change" src="https://user-images.githubusercontent.com/24986597/212499210-2d6fc9ec-49f8-40c8-ba78-c73c1f9f4959.png">

(I found it strange that `<video>` had `height: 100%` applied because I couldn't think of the meaning it implied. If there was a reason for that, let me know.)