### PR TITLE
[Videos] [Player] Pause currently playing video on tab switch

### DIFF
--- a/static/video.js
+++ b/static/video.js
@@ -468,13 +468,16 @@ class ReC98Video extends HTMLElement {
 			// this becomes an issue.
 			this.switchingVideos = true;
 
+			// Pause the old video, but save the previous playing state to
+			// decide whether to unpause the new video.
+			const videoPrevPaused = videoPrev.paused;
+			videoPrev.pause();
 			videoNew.onseeked = (() => {
 				videoNew.classList.add("active");
 				seekedFunc();
 				videoPrev.classList.remove("active");
-				if(!videoPrev.paused) {
+				if(!videoPrevPaused) {
 					videoNew.play();
-					videoPrev.pause();
 				}
 				this.switchingVideos = false;
 				videoNew.onseeked = seekedFunc;


### PR DESCRIPTION
This avoids the jump back in time when the new video takes some time seeking.

Here's a demo in an environment with a simulated slow network. Before:

https://user-images.githubusercontent.com/24986597/212569452-572a95d9-d1de-45a8-b198-e4612a274b9a.mp4

After:

https://user-images.githubusercontent.com/24986597/212569455-d9af53f6-84a7-4e35-9f95-5fdabab9b4fe.mp4