### PR TITLE
[Blog] Add a height attribute to emoji <img>s for feed readers

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,8 @@ func HTMLEmoji(emoji string) template.HTML {
 	}
 	url := staticHP.VersionURLFor("emoji-" + fn + ".png")
 	return template.HTML(fmt.Sprintf(
-		`<img src="%s" alt=":%s:" %s/>`, url, emoji, style,
+		`<img src="%s" alt=":%s:" height="24" align="top" %s/>`,
+		url, emoji, style,
 	))
 }
 


### PR DESCRIPTION
Prevents emojis from blowing up to their intrinsic size. The attribute is overriden on the website with CSS as intended.